### PR TITLE
[FEATURE] RSpec Custom Matcher for Main Application (Phase 1)

### DIFF
--- a/lib/kan/rspec.rb
+++ b/lib/kan/rspec.rb
@@ -2,6 +2,63 @@ module Kan
   module RSpec
     module Matchers
       extend ::RSpec::Matchers::DSL
+
+      matcher :permit do |ability|
+        match_proc = lambda do |app|
+          app[ability].call
+        end
+
+        match_when_negated_proc = lambda do |app|
+          !app[ability].call
+        end
+
+        failure_message_proc = lambda do |_app|
+          target, action = ability.split('.')
+          "Expected #{target} to grant #{action} but not granted"
+        end
+
+        failure_message_when_negated_proc = lambda do |_app|
+          target, action = ability.split('.')
+          "Expected #{target} not to grant #{action} but granted"
+        end
+
+        match(&match_proc)
+        match_when_negated(&match_when_negated_proc)
+        failure_message(&failure_message_proc)
+        failure_message_when_negated(&failure_message_when_negated_proc)
+      end
     end
+
+    module DSL
+      def permissions(&block)
+        describe(caller: caller) { instance_eval(&block) }
+      end
+    end
+
+    module AbilityExampleGroup
+      include Kan::RSpec::Matchers
+
+      def self.included(base)
+        base.metadata[:type] = :ability
+        base.extend Kan::RSpec::DSL
+        super
+      end
+    end
+  end
+end
+
+RSpec.configure do |config|
+  if RSpec::Core::Version::STRING.split(".").first.to_i >= 3
+    config.include(
+      Kan::RSpec::AbilityExampleGroup,
+      type: :ability,
+      file_path: %r{spec/abilites}
+    )
+  else
+    config.include(
+      Kan::RSpec::AbilityExampleGroup,
+      type: :ability,
+      example_group: { file_path: %r{spec/abilites} }
+    )
   end
 end

--- a/lib/kan/rspec.rb
+++ b/lib/kan/rspec.rb
@@ -1,0 +1,7 @@
+module Kan
+  module RSpec
+    module Matchers
+      extend ::RSpec::Matchers::DSL
+    end
+  end
+end

--- a/spec/abilities/application_spec.rb
+++ b/spec/abilities/application_spec.rb
@@ -1,4 +1,6 @@
-RSpec.describe Kan::Application do
+require 'spec_helper'
+
+RSpec.describe Kan::Application, type: :ability do
   class PostAbilities
     include Kan::Abilities
 
@@ -19,7 +21,7 @@ RSpec.describe Kan::Application do
     )
   end
 
-  permissions :read, :edit do
+  permissions do
     it "denies access for post edit" do
       expect(subject).not_to permit('post.edit')
     end
@@ -29,7 +31,7 @@ RSpec.describe Kan::Application do
     end
 
     it "denies access for user read" do
-      expect(subject).to permit('user.read')
+      expect(subject).not_to permit('user.read')
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,3 @@
 require 'rspec'
 require 'kan'
+require "kan/rspec"

--- a/spec/unit/application_custom_matcher_spec.rb
+++ b/spec/unit/application_custom_matcher_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe Kan::Application do
+  class PostAbilities
+    include Kan::Abilities
+
+    register('read') { |_| true }
+    register('edit') { |_, _| false }
+  end
+
+  class UserAbilities
+    include Kan::Abilities
+
+    register('read') { false }
+  end
+
+  subject do
+    Kan::Application.new(
+      user: UserAbilities.new,
+      post: PostAbilities.new
+    )
+  end
+
+  permissions :read, :edit do
+    it "denies access for post edit" do
+      expect(subject).not_to permit('post.edit')
+    end
+
+    it "grants access for post read" do
+      expect(subject).to permit('post.read')
+    end
+
+    it "denies access for user read" do
+      expect(subject).to permit('user.read')
+    end
+  end
+end


### PR DESCRIPTION
### Objective

Add the custom RSpec matcher to easily test on ability classes

### Feature

(1) A new custom matcher that simplifes what the `application_spec.rb` did in the first place

### TODO

(1) Functionalities to test on `user` and `post` object against the `Kan::Application`
(2) Support `should` syntax
