### PR TITLE
Renamed ambiguous ArgumentError to MissingScopeError when scope is mi…

### DIFF
--- a/lib/kan/application.rb
+++ b/lib/kan/application.rb
@@ -1,6 +1,7 @@
 module Kan
   class Application
     class InvalidScopeError < StandardError; end
+    class MissingScopeError < StandardError; end
 
     def initialize(scopes = {})
       raise(InvalidScopeError) unless scopes.is_a?(Hash)
@@ -28,7 +29,7 @@ module Kan
     private
 
     def raise_scope_error(scope)
-      raise ArgumentError.new("Invalid scope #{scope}")
+      raise MissingScopeError.new("Invalid scope #{scope}")
     end
   end
 end

--- a/spec/abilities/application_spec.rb
+++ b/spec/abilities/application_spec.rb
@@ -54,5 +54,12 @@ RSpec.describe Kan::Application, type: :ability do
         it { is_expected.to permit('user.delete', admin) }
       end
     end
+
+    describe "Missing Scope" do
+      it do
+        expect { subject['something.missing'] }
+          .to raise_error(Kan::Application::MissingScopeError)
+      end
+    end
   end
 end


### PR DESCRIPTION
…ssing in ability

Hi!

I want to be able to have something less ambiguous than ArgumentError.
1) to separate kan errors from others
2) to catch it more accurately

``` ruby
ability = Kan::Application.new(
      user: UserAbilities.new,
      post: PostAbilities.new
    )

def is_it_possible?
  %i[user post unmanaged].sample do |resource| 
    ability[[resource, action].join('.')].call(alien, _)
  end
rescue MissingScopeError
  default_rule
end
```

Best,
Anton